### PR TITLE
Correction of roi_pooling layers compilation

### DIFF
--- a/layers/roi_pooling/build.py
+++ b/layers/roi_pooling/build.py
@@ -17,7 +17,7 @@ if torch.cuda.is_available():
 
 this_file = os.path.dirname(os.path.realpath(__file__))
 print(this_file)
-extra_objects = ['src/cuda/roi_pooling.cu.o']
+extra_objects = ['src/cuda/roi_pooling_kernel.cu.o']
 extra_objects = [os.path.join(this_file, fname) for fname in extra_objects]
 
 ffi = create_extension(

--- a/make.sh
+++ b/make.sh
@@ -15,7 +15,7 @@ cd ../
 
 cd roi_pooling/src
 echo "Compiling roi_pooling kernels by nvcc..."
-nvcc -c -o reorg_cuda_kernel.cu.o reorg_cuda_kernel.cu -x cu -Xcompiler -fPIC -arch=sm_52
-cd ../
+nvcc -c -o roi_pooling_kernel.cu.o roi_pooling_kernel.cu -x cu -Xcompiler -fPIC -arch=sm_52
+cd ../../
 python build.py
 cd ../


### PR DESCRIPTION
There are minor mistakes in the `make.sh` and `layers/roi_pooling/build.py`, which will lead to compiling error.